### PR TITLE
A couple new SSHD configs from a recent SSG master

### DIFF
--- a/tasks/services/ssh_service.yml
+++ b/tasks/services/ssh_service.yml
@@ -122,6 +122,26 @@
     - AC-17
     - AC-17(2)
 
+- name: Disable SSH Support for User Known Hosts
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: ".*IgnoreUserKnownHosts.*no.*"
+    line: "IgnoreUserKnownHosts yes"
+  tags:
+    - CM
+    - CM-6
+    - CM-6(a)
+
+- name: Disable SSH Support for Rhosts RSA Authentication
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: ".*RhostsRSAAuthentication.*yes.*"
+    line: "RhostsRSAAuthentication no"
+  tags:
+    - CM
+    - CM-6
+    - CM-6(a)
+
 - name: Disable GSSAPI Authentication
   lineinfile:
     dest: /etc/ssh/sshd_config


### PR DESCRIPTION
Updates from https://github.com/OpenSCAP/scap-security-guide/pull/1537

I have to admit I'm a bit unclear on when to use `regexp` but since `RhostsRSAAuthentication` exists in a comment out of the box, I check for `".*RhostsRSAAuthentication.*yes.*"` (and do the same for `IgnoreUserKnownHosts`). Let me know if you'd rather have it in an alternate form.